### PR TITLE
Add two week schedule

### DIFF
--- a/src/src/components/Main/Schedule/ScheduleShell.tsx
+++ b/src/src/components/Main/Schedule/ScheduleShell.tsx
@@ -15,15 +15,17 @@ const useStyles = makeStyles(theme => ({
     left: 0,
     right: 0,
     bottom: 0,
-    display: "block",
-    flexDirection: "row",
+    display: "flex",
+    flexDirection: "column",
     alignItems: "flex-start",
-    overflow: "auto",
     backgroundColor: "#dedede"
   },
   scheduleContainer:{
+    flexGrow: 1,
+    width: "100%",
     display:"flex",
     alignItems: "flex-start",
+    overflow: "auto"
   },
   schedule: {
     position: "relative",
@@ -186,24 +188,24 @@ const ScheduleShell = (props:{
       : <></>}
       {/* Times */}
       <div className={classes.scheduleContainer}>
-      <div className={classes.timesColumn}>
-        <DayHeader>&nbsp;</DayHeader>
-        {hours.map(h => (
-          <Typography key={h} variant="h6" style={{height: heightOfHour}}>{moment().startOf('day').add(h, 'hour').format('LT')}</Typography>
-        ))}
-      </div>
-      <div className={classes.schedule}>
-        {arrangers.filter(i => (i.date.weekday() !== 0 && i.date.weekday() !== 6) || i.isValid).map((a, i) => (
-          <div key={i} className={classes.scheduleColumn} style={{backgroundColor: i % 2 == 0 ? "#eeeeee" : "#dedede"}}>
-            <DayHeader>{a.date.format('dddd')}</DayHeader>
-            <div className={classes.columnItems} style={{height: (maxHour - minHour + 1) * heightOfHour}}>
-              {a.scheduleItems.map(s => (
-                  <ScheduleItem key={s.item.identifier.toString()} schedule={s.item} height={s.height} topOffset={s.topOffset} week={week}/>
-              ))}
-            </div>
-          </div>
-        ))}
+        <div className={classes.timesColumn}>
+          <DayHeader>&nbsp;</DayHeader>
+          {hours.map(h => (
+            <Typography key={h} variant="h6" style={{height: heightOfHour}}>{moment().startOf('day').add(h, 'hour').format('LT')}</Typography>
+          ))}
         </div>
+        <div className={classes.schedule}>
+          {arrangers.filter(i => (i.date.weekday() !== 0 && i.date.weekday() !== 6) || i.isValid).map((a, i) => (
+            <div key={i} className={classes.scheduleColumn} style={{backgroundColor: i % 2 == 0 ? "#eeeeee" : "#dedede"}}>
+              <DayHeader>{a.date.format('dddd')}</DayHeader>
+              <div className={classes.columnItems} style={{height: (maxHour - minHour + 1) * heightOfHour}}>
+                {a.scheduleItems.map(s => (
+                    <ScheduleItem key={s.item.identifier.toString()} schedule={s.item} height={s.height} topOffset={s.topOffset} week={week}/>
+                ))}
+              </div>
+            </div>
+          ))}
+          </div>
       </div>
     </div>
   );

--- a/src/src/components/Main/Schedule/ScheduleShell.tsx
+++ b/src/src/components/Main/Schedule/ScheduleShell.tsx
@@ -163,12 +163,10 @@ const ScheduleShell = (props:{
     a.calculateOffsets();
   });
 
-  // create a state for current week displayed
+  // create state for current week displayed
   const [week, setWeek] = React.useState(1);
 
   const handleChange = (event:any, newValue:number) => {
-    console.log(newValue)
-    console.log(week)
     if(newValue === 0){
       setWeek(1);
     }
@@ -177,8 +175,18 @@ const ScheduleShell = (props:{
     }
   }
 
+  // check if any items have a week a or b schedule or if it's all set to every week
+  var multiWeek = false
+  arrangers.forEach(a => {
+    a.scheduleItems.forEach(s => {
+      if(s.item.scheduleWeek !== 3){
+        multiWeek = true
+      }
+    })
+  })
   return (
     <div className={classes.root}>
+      {multiWeek ?
       <AppBar position="static" color="secondary">
         <Toolbar className={classes.toolbar} variant="dense">
           <Tabs className={classes.tabs} value={week - 1} onChange={handleChange} indicatorColor="primary">
@@ -187,6 +195,7 @@ const ScheduleShell = (props:{
           </Tabs>
         </Toolbar>
       </AppBar>
+      : <></>}
       {/* Times */}
       <div className={classes.scheduleContainer}>
       <div className={classes.timesColumn}>

--- a/src/src/components/Main/Schedule/ScheduleShell.tsx
+++ b/src/src/components/Main/Schedule/ScheduleShell.tsx
@@ -8,18 +8,6 @@ import { Typography, makeStyles, Tabs, Tab, AppBar, Toolbar} from "@material-ui/
 const heightOfHour = 120;
 const width = 200;
 
-const TabPanel = (props:{
-  children: any,
-  value: number,
-  index: number
-}) => {
-  if (props.value === props.index) {
-    return props.children;
-  } else {
-    return null;
-  }
-}
-
 const useStyles = makeStyles(theme => ({
   root: {
     position: "absolute",

--- a/src/src/components/Main/Schedule/ScheduleShell.tsx
+++ b/src/src/components/Main/Schedule/ScheduleShell.tsx
@@ -3,10 +3,22 @@ import { ViewItemClass, ViewItemSchedule } from "models/viewItems";
 import DayScheduleItemsArranger from "models/dayScheduleItemsArranger";
 import * as moment from "moment";
 import ArrayHelpers from "helpers/arrayHelpers";
-import { Typography, makeStyles } from "@material-ui/core";
+import { Typography, makeStyles, Tabs, Tab, AppBar, Toolbar} from "@material-ui/core";
 
 const heightOfHour = 120;
 const width = 200;
+
+const TabPanel = (props:{
+  children: any,
+  value: number,
+  index: number
+}) => {
+  if (props.value === props.index) {
+    return props.children;
+  } else {
+    return null;
+  }
+}
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -15,11 +27,15 @@ const useStyles = makeStyles(theme => ({
     left: 0,
     right: 0,
     bottom: 0,
-    display: "flex",
+    display: "block",
     flexDirection: "row",
     alignItems: "flex-start",
     overflow: "auto",
     backgroundColor: "#dedede"
+  },
+  scheduleContainer:{
+    display:"flex",
+    alignItems: "flex-start",
   },
   schedule: {
     position: "relative",
@@ -48,7 +64,37 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(1),
     boxSizing: "border-box",
     overflow: "hidden"
-  }
+  },
+  weekSelectorButton:{
+    display: "block",
+    padding: theme.spacing(1),
+    margin: theme.spacing(1),
+    border: "1px solid black",
+    borderRadius: theme.spacing(1),
+    backgroundColor: "#dedede",
+    "&:hover": {
+      backgroundColor: "#eeeeee"
+    }
+  },
+  activeWeekSelectorButton:{
+    display: "block",
+    padding: theme.spacing(1),
+    margin: theme.spacing(1),
+    border: "1px solid black",
+    borderRadius: theme.spacing(1),
+    backgroundColor: "#eeeeee",
+    "&:hover": {
+      backgroundColor: "#dedede"
+    }
+  },
+  toolbar: {
+    alignItems: 'flex-start',
+    display: "block"
+  },
+  tabs: {
+    flexGrow: 1,
+    alignSelf: 'flex-end'
+  },
 }));
 
 const ScheduleShell = (props:{
@@ -61,11 +107,13 @@ const ScheduleShell = (props:{
     return <Typography variant="h6">{props.children}</Typography>
   }
 
-  const ScheduleItem = (props:{schedule:ViewItemSchedule, height:number, topOffset:number}) => {
+  const ScheduleItem = (props:{schedule:ViewItemSchedule, height:number, topOffset:number, week:number}) => {
     const s = props.schedule;
     const timeString = `${s.startDateTime.format("LT")} to ${s.endDateTime.format("LT")}`;
     const textVariant = "body2";
 
+    const week = props.week
+    if(props.schedule.scheduleWeek === 3 || props.schedule.scheduleWeek === week){
     return (
       <div className={classes.scheduleItem} style={{backgroundColor: s.class.color, height: props.height, top: props.topOffset}}>
         <Typography variant={textVariant}>{s.class.name}</Typography>
@@ -75,6 +123,11 @@ const ScheduleShell = (props:{
         )}
       </div>
     )
+    }else{
+      return (
+        <></>
+      )
+    }
   }
 
   const startOfWeek = moment().startOf('week');
@@ -110,10 +163,32 @@ const ScheduleShell = (props:{
     a.calculateOffsets();
   });
 
+  // create a state for current week displayed
+  const [week, setWeek] = React.useState(1);
+
+  const handleChange = (event:any, newValue:number) => {
+    console.log(newValue)
+    console.log(week)
+    if(newValue === 0){
+      setWeek(1);
+    }
+    else{
+      setWeek(2);
+    }
+  }
 
   return (
     <div className={classes.root}>
+      <AppBar position="static" color="secondary">
+        <Toolbar className={classes.toolbar} variant="dense">
+          <Tabs className={classes.tabs} value={week - 1} onChange={handleChange} indicatorColor="primary">
+            <Tab label="Week A"/>
+            <Tab label="Week B"/>
+          </Tabs>
+        </Toolbar>
+      </AppBar>
       {/* Times */}
+      <div className={classes.scheduleContainer}>
       <div className={classes.timesColumn}>
         <DayHeader>&nbsp;</DayHeader>
         {hours.map(h => (
@@ -126,11 +201,12 @@ const ScheduleShell = (props:{
             <DayHeader>{a.date.format('dddd')}</DayHeader>
             <div className={classes.columnItems} style={{height: (maxHour - minHour + 1) * heightOfHour}}>
               {a.scheduleItems.map(s => (
-                <ScheduleItem key={s.item.identifier.toString()} schedule={s.item} height={s.height} topOffset={s.topOffset}/>
+                  <ScheduleItem key={s.item.identifier.toString()} schedule={s.item} height={s.height} topOffset={s.topOffset} week={week}/>
               ))}
             </div>
           </div>
         ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Hi,

Here's some code I wrote to make two week schedule work in the webapp.
![image](https://github.com/powerplanner/powerplannerwebapp/assets/74068072/7161a7f9-cd57-4511-8c50-80565ec8757d)

It does have a few issues that I can't resolve:

- Untested with single week timetable users (There's no reason why it wouldn't work, they would still have the week tab bar though)
- If the screen size is small, and the schedule is bigger than the viewport, the user can scroll horisontally, but the tab bar isn't wider so it it just blank space (sorry I know that's not worded very well, here's a screenshot)
- I was unsure what code style conventions to follow or tools to use (prettier etc), apologies if the code is inconsistent with the style of the rest of the codebase

![image](https://github.com/powerplanner/powerplannerwebapp/assets/74068072/54c04684-835f-4587-b3a0-a26b0f54753c)
